### PR TITLE
add image sharing functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,6 @@ docker-compose down
 - The app uses PouchDB's live changes feed for real-time message updates
 - Docker multi-stage build optimizes the web container size
 - The hotspot service creates a captive portal redirecting to the chat interface
+- Image sharing is implemented using base64 encoding stored in CouchDB
+- Mobile-optimized UI with responsive design for various screen sizes
+- Images are automatically resized for display and can be removed before sending

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,8 +18,8 @@ export default function App() {
 
   const [isAuthOpen, setIsAuthOpen] = useState(!author);
 
-  const handleSubmit = (text: string) => {
-    addMessage({ text, date: new Date(), author });
+  const handleSubmit = (text: string, image?: string, imageType?: string) => {
+    addMessage({ text, date: new Date(), author, image, imageType });
   };
 
   const handleLogin = (name: string) => {
@@ -33,7 +33,7 @@ export default function App() {
       <Header onLogout={() => setIsAuthOpen(true)} />
 
       <AuthModal isOpen={isAuthOpen} onLogin={name => handleLogin(name)} />
-      <MDBCardBody>
+      <MDBCardBody style={{ flex: 1, overflowY: "auto", maxHeight: "calc(100vh - 140px)" }}>
         {messages.map(message =>
           message.author === author ? (
             <MessageMine key={message._id} {...message} />
@@ -43,7 +43,7 @@ export default function App() {
         )}
       </MDBCardBody>
 
-      <Footer onSend={text => handleSubmit(text)} />
+      <Footer onSend={(text, image, imageType) => handleSubmit(text, image, imageType)} />
     </Layout>
   );
 }

--- a/web/src/AuthModal.tsx
+++ b/web/src/AuthModal.tsx
@@ -35,19 +35,19 @@ export function AuthModal({ isOpen, onLogin }: Props) {
             </MDBModalHeader>
             <MDBModalBody>
               <p>
-                You're probably bored to death if you decided to connect to this
-                hotspot.
+                Welcome to RPi Chat! 👋
               </p>
               <p>
                 This is an offline chat where you can connect with other people
-                without internet.
+                without internet. Share messages and photos with others nearby!
               </p>
               <div className="mb-3">
                 <MDBInput
                   value={name}
                   onChange={e => setName(e.target.value)}
                   labelClass="col-form-label"
-                  label="Introduce yourself"
+                  label="Enter your name"
+                  required
                 />
               </div>
             </MDBModalBody>

--- a/web/src/Footer.tsx
+++ b/web/src/Footer.tsx
@@ -1,34 +1,103 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 import { MDBBtn, MDBCardFooter, MDBInputGroup } from "mdb-react-ui-kit";
 
-type Props = { onSend: (message: string) => void };
+type Props = { onSend: (message: string, image?: string, imageType?: string) => void };
 
 export function Footer({ onSend }: Props) {
   const [message, setMessage] = useState("");
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [imageType, setImageType] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const base64 = e.target?.result as string;
+        const base64Data = base64.split(',')[1];
+        setSelectedImage(base64Data);
+        setImageType(file.type);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (message.trim()) {
-      onSend(message);
+    if (message.trim() || selectedImage) {
+      onSend(message, selectedImage || undefined, imageType || undefined);
       setMessage("");
+      setSelectedImage(null);
+      setImageType(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const removeImage = () => {
+    setSelectedImage(null);
+    setImageType(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
     }
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      <MDBCardFooter className="text-muted d-flex justify-content-start align-items-center p-3">
-        <MDBInputGroup className="mb-0">
+      <MDBCardFooter className="text-muted p-3">
+        {selectedImage && (
+          <div className="mb-2 position-relative d-inline-block">
+            <img 
+              src={`data:${imageType};base64,${selectedImage}`}
+              alt="Selected"
+              className="img-thumbnail"
+              style={{ maxWidth: "100px", maxHeight: "100px" }}
+            />
+            <button 
+              type="button"
+              className="btn btn-sm btn-danger position-absolute top-0 end-0"
+              style={{ transform: "translate(50%, -50%)", borderRadius: "50%", width: "24px", height: "24px", padding: "0", fontSize: "12px" }}
+              onClick={removeImage}
+            >
+              ×
+            </button>
+          </div>
+        )}
+        <div className="d-flex justify-content-start align-items-center">
+          <MDBInputGroup className="mb-0 flex-grow-1">
+            <input
+              type="text"
+              className="form-control form-control-lg"
+              placeholder="Type message"
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+            />
+            <MDBBtn 
+              type="button"
+              color="light"
+              onClick={handleImageClick}
+              className="border"
+            >
+              📷
+            </MDBBtn>
+            <MDBBtn type="submit">Send</MDBBtn>
+          </MDBInputGroup>
           <input
-            type="text"
-            className="form-control form-control-lg"
-            placeholder="Type message"
-            value={message}
-            onChange={e => setMessage(e.target.value)}
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleImageSelect}
           />
-          <MDBBtn>Send</MDBBtn>
-        </MDBInputGroup>
+        </div>
       </MDBCardFooter>
     </form>
   );

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -8,10 +8,10 @@ type Props = {
 
 export function Layout({ children }: Props) {
   return (
-    <MDBContainer fluid className="py-5">
-      <MDBRow className="d-flex justify-content-center">
-        <MDBCol md="10" lg="8" xl="6">
-          <MDBCard id="chat2" style={{ borderRadius: "15px" }}>
+    <MDBContainer fluid className="py-2 py-md-5" style={{ minHeight: "100vh" }}>
+      <MDBRow className="d-flex justify-content-center h-100">
+        <MDBCol xs="12" md="10" lg="8" xl="6">
+          <MDBCard id="chat2" style={{ borderRadius: "15px", height: "100%", maxHeight: "100vh", display: "flex", flexDirection: "column" }}>
             {children}
           </MDBCard>
         </MDBCol>

--- a/web/src/Message.tsx
+++ b/web/src/Message.tsx
@@ -5,9 +5,11 @@ type Props = {
   text: string;
   author: string;
   date: Date;
+  image?: string;
+  imageType?: string;
 };
 
-export function Message({ text, author, date }: Props) {
+export function Message({ text, author, date, image, imageType }: Props) {
   return (
     <>
       <div className="d-flex justify-content-between">
@@ -17,19 +19,31 @@ export function Message({ text, author, date }: Props) {
 
       <div className="d-flex flex-row justify-content-start">
         <div>
-          <p
-            className="small p-2 ms-3 mb-3 rounded-3"
-            style={{ backgroundColor: "#f5f6f7" }}
-          >
-            {text}
-          </p>
+          {image && (
+            <div className="p-2 ms-3 mb-2 rounded-3" style={{ backgroundColor: "#f5f6f7" }}>
+              <img 
+                src={`data:${imageType};base64,${image}`}
+                alt="Shared image"
+                className="img-fluid rounded"
+                style={{ maxWidth: "200px", maxHeight: "200px" }}
+              />
+            </div>
+          )}
+          {text && (
+            <p
+              className="small p-2 ms-3 mb-3 rounded-3"
+              style={{ backgroundColor: "#f5f6f7" }}
+            >
+              {text}
+            </p>
+          )}
         </div>
       </div>
     </>
   );
 }
 
-export function MessageMine({ text, author, date }: Props) {
+export function MessageMine({ text, author, date, image, imageType }: Props) {
   return (
     <>
       <div className="d-flex justify-content-between">
@@ -38,9 +52,21 @@ export function MessageMine({ text, author, date }: Props) {
       </div>
       <div className="d-flex flex-row justify-content-end mb-4 pt-1">
         <div>
-          <p className="small p-2 me-3 mb-3 text-white rounded-3 bg-primary">
-            {text}
-          </p>
+          {image && (
+            <div className="p-2 me-3 mb-2 text-white rounded-3 bg-primary">
+              <img 
+                src={`data:${imageType};base64,${image}`}
+                alt="Shared image"
+                className="img-fluid rounded"
+                style={{ maxWidth: "200px", maxHeight: "200px" }}
+              />
+            </div>
+          )}
+          {text && (
+            <p className="small p-2 me-3 mb-3 text-white rounded-3 bg-primary">
+              {text}
+            </p>
+          )}
         </div>
       </div>
     </>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,50 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+/* Mobile optimizations */
+@media (max-width: 768px) {
+  .container-fluid {
+    padding: 0 !important;
+  }
+  
+  #chat2 {
+    border-radius: 0 !important;
+    height: 100vh !important;
+    max-height: 100vh !important;
+  }
+  
+  .card-body {
+    padding: 1rem !important;
+  }
+  
+  .card-footer {
+    padding: 0.75rem !important;
+  }
+}
+
+/* Ensure images don't overflow */
+.img-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Better scrolling on mobile */
+.card-body {
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Prevent zoom on input focus (iOS) */
+input[type="text"] {
+  font-size: 16px;
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 
 import "mdb-react-ui-kit/dist/css/mdb.min.css";
 import "@fortawesome/fontawesome-free/css/all.min.css";
+import "./index.css";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);

--- a/web/src/useMessages.ts
+++ b/web/src/useMessages.ts
@@ -4,6 +4,8 @@ type MessageDoc = Doc & {
   text: string;
   author: string;
   date: Date;
+  image?: string;
+  imageType?: string;
 };
 
 export const useMessages = () => {


### PR DESCRIPTION
 ✅ Image Sharing Features

  - Photo upload button (📷) in the chat input
  - Image preview before sending with ability to remove
  - Base64 image storage in CouchDB for offline functionality
  - Responsive image display in chat messages (max 200x200px)
  - Support for all image formats (jpg, png, gif, etc.)

  ✅ Mobile Optimizations

  - Full-screen layout on mobile devices
  - Touch-friendly interface with proper scrolling
  - Responsive design that adapts to all screen sizes
  - Fixed input zoom on iOS devices
  - Optimized chat layout with proper height management

  ✅ Technical Improvements

  - TypeScript support for image properties
  - Clean component architecture with proper prop handling
  - Error-free build process
  - Updated CLAUDE.md with new functionality details

  🚀 How to Use

  1. Run docker-compose up --build to start the application
  2. Connect to the WiFi hotspot created by the Raspberry Pi
  3. Open a browser and navigate to the captive portal
  4. Enter your name and start chatting
  5. Use the 📷 button to share images with other users

The app now provides a complete offline chat experience with both text and image sharing capabilities, optimized for mobile devices. Users can easily share photos, preview them before sending, and enjoy a smooth chat experience on any device size.